### PR TITLE
modify url in .rockspec

### DIFF
--- a/rocks/decisiontree-scm-1.rockspec
+++ b/rocks/decisiontree-scm-1.rockspec
@@ -2,7 +2,7 @@ package = "decisiontree"
 version = "scm-1"
 
 source = {
-   url = "git://github.com/Twitter/decisiontree",
+   url = "git://github.com/Twitter/torch-decisiontree",
    tag = "master"
 }
 


### PR DESCRIPTION
Current repo name is __torch-decisiontree__, not decisiontree.